### PR TITLE
fix: exclude capi from pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
   build: {
     target: 'esnext',
   },
+  optimizeDeps: {
+    exclude: ['capi'],
+  },
 })


### PR DESCRIPTION
fixes https://github.com/paritytech/capi-multisig-app/issues/77

Vite is doing something called pre-bundling during development because it serves ESM modules to the browser and some dependencies need to be transformed

From the docs: If the dependency is small and is already valid ESM, you can exclude it and let the browser load it directly.

Excluding Capi from this optimization results in the dev server starting properly, only that there is a runtime error now:

```
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/@deno+shim-deno-test@0.4.0/node_modules/@deno/shim-deno-test/dist/index.js?v=d5970e60' does not provide an export named 'Deno' (at _dnt.shims.ts:1:10)
```