### PR TITLE
fix: change default server port from 5000 to 5555

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY . /capi-multisig-app/
 
 RUN pnpm run build:server
 
-EXPOSE 5000
+EXPOSE 5555
 CMD [ "node", "server/dist/main.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
     build:
       context: ./
     ports:
-      - "80:5000"
+      - "80:5555"

--- a/server/main.ts
+++ b/server/main.ts
@@ -17,7 +17,7 @@ const httpServer = http.createServer(app)
 const wsServer = new ws.WebSocketServer({ noServer: true })
 const channels: Record<string, Set<ws.WebSocket>> = {}
 
-const port = process.env.PORT ?? 5000
+const port = 5555
 httpServer.listen(port, () => {
   console.log(`Listening on http://localhost:${port}`)
 })


### PR DESCRIPTION
5000 is used for Control Center on most recent Mac OS. Furthermore removes option to specify port via environment variable, as it's ignored by the docker setup, which could just lead to misconfiguration in the future.

One could make these changes in the default settings to free up 5000 again but it's on by default. Which is annoying for anyone contributing not knowing about this. So maybe it's just easier to change the default port.

https://developer.apple.com/forums/thread/682332