### PR TITLE
refactor: optional `name` for `<AccountId />`

### DIFF
--- a/www/src/components/AccountId.tsx
+++ b/www/src/components/AccountId.tsx
@@ -1,35 +1,35 @@
-import { WalletAccount } from "@talisman-connect/wallets"
 import { clsx } from "clsx"
 import { Identicon } from "../components/identicon/Identicon.js"
 import { shortAddress } from "../util/address.js"
 
 interface Props {
-  account?: Partial<WalletAccount> & { address: string }
+  name?: string
+  address?: string
   shortenAddress?: boolean
 }
 
-export function AccountId({ account, shortenAddress = true }: Props) {
-  if (!account) return null
-
+export function AccountId(
+  { name = "", address = "", shortenAddress = true }: Props,
+) {
   return (
     <div className="flex">
       <Identicon
         size={24}
-        value={account.address}
+        value={address}
         className="mr-2"
       />
 
-      {account.name && (
+      {name && (
         <span className="font-bold mr-2">
-          {account.name}
+          {name}
         </span>
       )}
-        
+
       <span
-        title={account.address}
-        className={clsx({ truncate: shortAddress })}
+        title={address}
+        className={clsx({ truncate: shortenAddress })}
       >
-        {shortenAddress ? shortAddress(account.address) : account.address}
+        {shortenAddress ? shortAddress(address) : address}
       </span>
     </div>
   )

--- a/www/src/components/Setup.tsx
+++ b/www/src/components/Setup.tsx
@@ -1,4 +1,3 @@
-import { WalletAccount } from "@talisman-connect/wallets"
 import { Setup as SetupType } from "common"
 import { AccountId } from "./AccountId.js"
 import { Button } from "./Button.js"
@@ -46,10 +45,8 @@ export function Setup({ setup }: Props) {
             {setup.members.map((member, index) => (
               <AccountId
                 shortenAddress={false}
-                account={{
-                  address: member[0],
-                  name: "Member " + (index + 1),
-                } as WalletAccount}
+                address={member[0]}
+                name={"Member " + (index + 1)}
               />
             ))}
           </div>

--- a/www/src/components/wizards/multisig/Init.tsx
+++ b/www/src/components/wizards/multisig/Init.tsx
@@ -58,7 +58,10 @@ export function MultisigInit() {
       />
       <label className="mb-2 inline-block">Creator</label>
       <div className="mb-4">
-        <AccountId account={defaultAccount.value} />
+        <AccountId
+          address={defaultAccount.value?.address}
+          name={defaultAccount.value?.name}
+        />
       </div>
       <div className="flex gap-8 justify-start">
         <Controller

--- a/www/src/components/wizards/transaction/New.tsx
+++ b/www/src/components/wizards/transaction/New.tsx
@@ -55,7 +55,10 @@ export function TransactionNew() {
         <div class="flex flex-col gap-4">
           <div className="space-y-2">
             <p className="mt-4 text-[#321D47]">Initiated by:</p>
-            <AccountId account={selectedAccount.value} />
+            <AccountId
+              address={selectedAccount.value?.address}
+              name={selectedAccount.value?.name}
+            />
           </div>
           <div className="space-y-2">
             <Controller

--- a/www/src/components/wizards/transaction/Sign.tsx
+++ b/www/src/components/wizards/transaction/Sign.tsx
@@ -34,16 +34,16 @@ export function TransactionSign() {
       <div className="pt-6">Existing approvals: 0/?</div>
       <div className="flex flex-wrap pt-6">
         <div className="mr-2">{`Sending ${amount} WND from `}</div>
-        <AccountId account={from} />
+        <AccountId address={from?.address} name={from?.name} />
         <div>to {to}</div>
       </div>
       <div className="flex flex-wrap pt-6">
         <div className="mr-2">Creator</div>
-        <AccountId account={from} />
+        <AccountId address={from?.address} name={from?.name} />
       </div>
       <div className="flex flex-wrap pt-6">
         <div className="mr-2">Signing as:</div>
-        <AccountId account={from} />
+        <AccountId address={from?.address} name={from?.name} />
       </div>
       <div>
         <div class="pt-4 flex justify-end">

--- a/www/src/pages/dashboard.tsx
+++ b/www/src/pages/dashboard.tsx
@@ -26,7 +26,10 @@ export function Dashboard() {
               </div>
               <div className="mt-14 flex flex-wrap items-center">
                 <p className="leading-8 mr-2">Create a Multisig with address</p>
-                <AccountId account={defaultAccount.value} />
+                <AccountId
+                  address={defaultAccount.value?.address}
+                  name={defaultAccount.value?.name}
+                />
               </div>
               <p className="leading-8">
                 Multi-signature wallets require authorization of transactions
@@ -40,6 +43,24 @@ export function Dashboard() {
                 </a>
               </p>
             </div>
+            <div className="mt-14 flex flex-wrap items-center">
+              <p className="leading-8 mr-2">Create a Multisig with address</p>
+              <AccountId
+                address={defaultAccount.value?.address}
+                name={defaultAccount.value?.name}
+              />
+            </div>
+            <p className="leading-8">
+              Multi-signature wallets require authorization of transactions
+              through multiple keys.&nbsp;
+              <a
+                href="https://wiki.polkadot.network/docs/learn-account-multisig"
+                target="_blank"
+                className="text-link hover:text-link/80 underline"
+              >
+                Learn more about multisigs.
+              </a>
+            </p>
           </div>
         </CenteredCard>
       </div>


### PR DESCRIPTION
makes all keys `WalletAccount` optional, except `address`.
https://github.com/paritytech/capi-multisig-app/blob/55bc22c93f5e8a4398ae2dfe006fcb24c14bc1f0/www/src/components/AccountId.tsx#L7

Further changes to the component are based on https://github.com/paritytech/capi-multisig-app/pull/161.

Btw @statictype how do you feel about making `account` itself not optional. For me it's a bit odd to have handle the missing value in the component itself. So just returning `null`. I would rather handle the missing of this value at the parent component. 

Closes #158.