### PR TITLE
feat: show transaction fee

### DIFF
--- a/www/src/components/FeesTable.tsx
+++ b/www/src/components/FeesTable.tsx
@@ -39,7 +39,7 @@ export function FeesTable({ fees }: Props) {
       <Tooltip id="my-tooltip" />
       <div className="flex justify-between border-t pt-4 mt-2">
         <span>Total</span>
-        <span>{formatBalance(total)}</span>
+        <span>{formatBalance(total)} WND</span>
       </div>
     </div>
   )

--- a/www/src/components/wizards/multisig/Members.tsx
+++ b/www/src/components/wizards/multisig/Members.tsx
@@ -24,19 +24,19 @@ const multisigCreationFees: Fee[] = [
   {
     name: "Existential deposit PureProxy",
     value: existentialDeposit,
-    displayValue: formatBalance(existentialDeposit),
+    displayValue: `${formatBalance(existentialDeposit)} WND`,
     info: "Amount to pay in order to keep the account alive",
   },
   {
     name: "Existential deposit Multisig",
     value: existentialDeposit,
-    displayValue: formatBalance(existentialDeposit),
+    displayValue: `${formatBalance(existentialDeposit)} WND`,
     info: "Amount to pay in order to keep the account alive",
   },
   {
     name: "Proxy fee",
     value: proxyDepositBase + proxyDepositFactor,
-    displayValue: formatBalance(proxyDepositBase + proxyDepositFactor),
+    displayValue: `${formatBalance(proxyDepositBase + proxyDepositFactor)} WND`,
     info:
       "Amount reserved for the creation of a PureProxy that holds the multisig funds. The multisig account acts as AnyProxy for this account.",
   },

--- a/www/src/components/wizards/transaction/signals.ts
+++ b/www/src/components/wizards/transaction/signals.ts
@@ -1,0 +1,25 @@
+import { MultiAddress, Westend, westend } from "@capi/westend"
+import { effect, Signal, signal } from "@preact/signals"
+import { ExtrinsicRune, ss58 } from "capi"
+import { defaultAccount } from "../../../signals/index.js"
+import { formData } from "./formData.js"
+
+export const selectedAccount = signal(defaultAccount.value)
+export const call = signal<ExtrinsicRune<Westend, never> | undefined>(undefined)
+export const fee: Signal<bigint> = signal(0n)
+
+effect(() => {
+  if (!formData.value.to) return
+  const addressPubKey = ss58.decode(formData.value.to)[1]
+  call.value = westend.Balances
+    .transferKeepAlive({
+      value: BigInt(formData.value.amount),
+      dest: MultiAddress.Id(addressPubKey),
+    })
+})
+
+effect(() => {
+  call.value?.estimate().run().then((estimate: bigint) => {
+    fee.value = estimate
+  })
+})

--- a/www/src/util/balance.ts
+++ b/www/src/util/balance.ts
@@ -1,18 +1,10 @@
 import { westend } from "@capi/westend"
 import { ss58 } from "capi"
 
-type Token = "DOT" | "KSM" | "WND"
-
 export function formatBalance(
   balance: bigint,
-  { decimalPoints = 4, tokenSymbol = "WND" as Token, chainDecimals = 12 } = {},
+  { decimalPoints = 4, chainDecimals = 12 } = {},
 ) {
-  const formatter = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: tokenSymbol,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 4,
-  })
   let units = ""
   let decimals = ""
   const str = balance.toString()
@@ -23,11 +15,10 @@ export function formatBalance(
     decimals = str.slice(diff, diff + decimalPoints)
   } else {
     units = "0"
-    decimals = "0".repeat(Math.abs(diff)).concat(str.slice(0, decimalPoints))
-      .slice(0, decimalPoints)
+    decimals = "0".repeat(Math.abs(diff)).concat(str)
   }
 
-  return formatter.format(Number(`${units}.${decimals}`))
+  return Number(Number(`${units}.${decimals}`).toFixed(4))
 }
 
 export async function getBalance(address: string) {


### PR DESCRIPTION
Not sure if this is the proper way to calculate and update the fee with signals and react-hook-form. Happy to get improvement suggestions.

https://github.com/paritytech/capi-multisig-app/blob/bb8ba5e29c0b6f201fbc6bdd31d9f083d0c1a4cf/www/src/components/wizards/transaction/New.tsx#L48-L62

I assumed the `estimate` value is the transaction fee? Not sure what the `weight` value is about which is also fetched in the capi example here:
https://github.com/paritytech/capi/pull/960/files#diff-6f461f22ed9fb691122d233fd2d00549c3a297397fffc3db4c7d771a0bf64e7dR18-R23