### PR TITLE
refactor: use signals + format fee

### DIFF
--- a/www/src/components/FeesTable.tsx
+++ b/www/src/components/FeesTable.tsx
@@ -39,7 +39,7 @@ export function FeesTable({ fees }: Props) {
       <Tooltip id="my-tooltip" />
       <div className="flex justify-between border-t pt-4 mt-2">
         <span>Total</span>
-        <span>{formatBalance(total)}</span>
+        <span>{formatBalance(total)} WND</span>
       </div>
     </div>
   )

--- a/www/src/components/wizards/multisig/Members.tsx
+++ b/www/src/components/wizards/multisig/Members.tsx
@@ -24,19 +24,19 @@ const multisigCreationFees: Fee[] = [
   {
     name: "Existential deposit PureProxy",
     value: existentialDeposit,
-    displayValue: formatBalance(existentialDeposit),
+    displayValue: `${formatBalance(existentialDeposit)} WND`,
     info: "Amount to pay in order to keep the account alive",
   },
   {
     name: "Existential deposit Multisig",
     value: existentialDeposit,
-    displayValue: formatBalance(existentialDeposit),
+    displayValue: `${formatBalance(existentialDeposit)} WND`,
     info: "Amount to pay in order to keep the account alive",
   },
   {
     name: "Proxy fee",
     value: proxyDepositBase + proxyDepositFactor,
-    displayValue: formatBalance(proxyDepositBase + proxyDepositFactor),
+    displayValue: `${formatBalance(proxyDepositBase + proxyDepositFactor)} WND`,
     info:
       "Amount reserved for the creation of a PureProxy that holds the multisig funds. The multisig account acts as AnyProxy for this account.",
   },

--- a/www/src/components/wizards/transaction/New.tsx
+++ b/www/src/components/wizards/transaction/New.tsx
@@ -3,6 +3,7 @@ import { hex } from "capi"
 import { useEffect } from "preact/hooks"
 import { Controller, SubmitHandler, useForm } from "react-hook-form"
 import { accounts } from "../../../signals/index.js"
+import { formatBalance } from "../../../util/balance.js"
 import { AccountId } from "../../AccountId.js"
 import { AccountSelect } from "../../AccountSelect.js"
 import { AddressInput } from "../../AddressInput.js"
@@ -112,8 +113,8 @@ export function TransactionNew() {
         </div>
         <div class="pt-4">
           <Table unit="WND">
-            <Table.Item name="Send" fee={watch("amount", 0)} />
-            <Table.Item name="Transaction Fee" fee={fee.value} />
+            <Table.Item name="Send" fee={formData.value.amount} />
+            <Table.Item name="Transaction Fee" fee={formatBalance(fee.value)} />
           </Table>
         </div>
         <div class="pt-4 flex justify-end">

--- a/www/src/components/wizards/transaction/signals.ts
+++ b/www/src/components/wizards/transaction/signals.ts
@@ -6,7 +6,7 @@ import { formData } from "./formData.js"
 
 export const selectedAccount = signal(defaultAccount.value)
 export const call = signal<ExtrinsicRune<Westend, never> | undefined>(undefined)
-export const fee: Signal<number> = signal(0)
+export const fee: Signal<bigint> = signal(0n)
 
 effect(() => {
   if (!formData.value.to) return
@@ -19,7 +19,7 @@ effect(() => {
 })
 
 effect(() => {
-  call.value?.estimate().run().then((estimate: BigInt) => {
-    fee.value = Number(estimate)
+  call.value?.estimate().run().then((estimate: bigint) => {
+    fee.value = estimate
   })
 })

--- a/www/src/util/balance.ts
+++ b/www/src/util/balance.ts
@@ -1,18 +1,10 @@
 import { westend } from "@capi/westend"
 import { ss58 } from "capi"
 
-type Token = "DOT" | "KSM" | "WND"
-
 export function formatBalance(
   balance: bigint,
-  { decimalPoints = 4, tokenSymbol = "WND" as Token, chainDecimals = 12 } = {},
+  { decimalPoints = 4, chainDecimals = 12 } = {},
 ) {
-  const formatter = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: tokenSymbol,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 4,
-  })
   let units = ""
   let decimals = ""
   const str = balance.toString()
@@ -23,11 +15,10 @@ export function formatBalance(
     decimals = str.slice(diff, diff + decimalPoints)
   } else {
     units = "0"
-    decimals = "0".repeat(Math.abs(diff)).concat(str.slice(0, decimalPoints))
-      .slice(0, decimalPoints)
+    decimals = "0".repeat(Math.abs(diff)).concat(str)
   }
 
-  return formatter.format(Number(`${units}.${decimals}`))
+  return Number(Number(`${units}.${decimals}`).toFixed(4))
 }
 
 export async function getBalance(address: string) {


### PR DESCRIPTION
This is how it would look with signals. 

Modified `formatBalance` to return numbers because the fees table used here only accepts numbers. I think the better approach is to distinguish between the numeric value and the formatted display string, like in the other table component. 
