### PR TITLE
feat: show account name if available through connected wallet

### DIFF
--- a/www/src/components/Setup.tsx
+++ b/www/src/components/Setup.tsx
@@ -1,6 +1,7 @@
 import { Setup as SetupType } from "common"
 
 import { Link } from "react-router-dom"
+import { accounts } from "../signals/accounts.js"
 import { AccountId } from "./AccountId.js"
 import { Button } from "./Button.js"
 import { CenteredCard } from "./CenteredCard.js"
@@ -48,7 +49,8 @@ export function Setup({ setup }: Props) {
               <AccountId
                 shortenAddress={false}
                 address={member[0]}
-                name={"Member " + (index + 1)}
+                name={accounts.value.find((a) => a.address === member[0])?.name
+                  || "Member " + (index + 1)}
               />
             ))}
           </div>


### PR DESCRIPTION
[`Show account name on the multisig card #189`](https://github.com/paritytech/capi-multisig-app/issues/189)

Not an ideal implementation but just wanted to start the conversation on this. As multsig probably consist of accounts which are not own by a single entity in his extension this implementation is not adding much value. We either need to implement our own address book or leverage existing implementation at best. Not sure what is already out there and how to use this yet.

<img width="867" alt="Screenshot 2023-06-05 at 11 58 31" src="https://github.com/paritytech/capi-multisig-app/assets/839848/dc3567ec-e53b-487e-9105-2d6975284a13">

---

Resources

+ polkadotjs address book - https://support.polkadot.network/support/solutions/articles/65000170036-polkadot-js-ui-the-difference-between-accounts-and-address-book
+ Subwallet address book - https://docs.subwallet.app/main/extension-user-guide/manage-address-book