### PR TITLE
chore: added basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Continuous Integration
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+      
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Install
+        run: pnpm install
+
+      - name: Build
+        run: pnpm compile
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
Added a basic GitHub workflow validating that the whole project correctly builds.
Triggered on main branch push on per PR.